### PR TITLE
feat: create downstream osv-offline and implement container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A collection of packages for using [Open Source Vulnerabilities](https://osv.dev
 
 | Name                                                                | Version                                                                                                                                               |
 | ------------------------------------------------------------------- |-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`@renovatebot/osv-offline`](./packages/osv-offline)                 | [![](https://img.shields.io/npm/v/@renovatebot/osv-offline?style=for-the-badge)](https://www.npmjs.com/package/@renovatebot/osv-offline)              |
-| [`@renovatebot/osv-offline-db`](./packages/osv-offline-db)           | [![](https://img.shields.io/npm/v/@renovatebot/osv-offline-db?style=for-the-badge)](https://www.npmjs.com/package/@renovatebot/osv-offline-db)        |
-| [`@renovatebot/osv-offline-updater`](./packages/osv-offline-updater) | [![](https://img.shields.io/github/v/release/renovatebot/osv-offline?style=for-the-badge)](https://github.com/renovatebot/osv-offline/releases/latest) |
+| [`@mintmaker/osv-offline`](./packages/osv-offline)                 | [![](https://img.shields.io/npm/v/@mintmaker/osv-offline?style=for-the-badge)](https://www.npmjs.com/package/@mintmaker/osv-offline)              |
+| [`@mintmaker/osv-offline-db`](./packages/osv-offline-db)           | [![](https://img.shields.io/npm/v/@mintmaker/osv-offline-db?style=for-the-badge)](https://www.npmjs.com/package/@mintmaker/osv-offline-db)        |
+| [`@mintmaker/osv-offline-updater`](./packages/osv-offline-updater) | [![](https://img.shields.io/github/v/release/mintmaker/osv-offline?style=for-the-badge)](https://github.com/mintmaker/osv-offline/releases/latest) |
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@renovatebot/osv-offline-monorepo",
+  "name": "@mintmaker/osv-offline-monorepo",
   "version": "0.0.0-semantic-release",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@renovatebot/osv-offline-monorepo",
+      "name": "@mintmaker/osv-offline-monorepo",
       "version": "0.0.0-semantic-release",
       "workspaces": [
         "./packages/*"
@@ -1528,15 +1528,15 @@
         "yarn": ">=1.0.0"
       }
     },
-    "node_modules/@renovatebot/osv-offline": {
+    "node_modules/@mintmaker/osv-offline": {
       "resolved": "packages/osv-offline",
       "link": true
     },
-    "node_modules/@renovatebot/osv-offline-db": {
+    "node_modules/@mintmaker/osv-offline-db": {
       "resolved": "packages/osv-offline-db",
       "link": true
     },
-    "node_modules/@renovatebot/osv-offline-updater": {
+    "node_modules/@mintmaker/osv-offline-updater": {
       "resolved": "packages/osv-offline-updater",
       "link": true
     },
@@ -14369,12 +14369,12 @@
       }
     },
     "packages/osv-offline": {
-      "name": "@renovatebot/osv-offline",
+      "name": "@mintmaker/osv-offline",
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^20.1.1",
-        "@renovatebot/osv-offline-db": "0.0.0-semantic-release",
+        "@mintmaker/osv-offline-db": "0.0.0-semantic-release",
         "adm-zip": "~0.5.16",
         "fs-extra": "^11.2.0",
         "got": "^11.8.6",
@@ -14393,7 +14393,7 @@
       }
     },
     "packages/osv-offline-db": {
-      "name": "@renovatebot/osv-offline-db",
+      "name": "@mintmaker/osv-offline-db",
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
@@ -14433,12 +14433,12 @@
       }
     },
     "packages/osv-offline-updater": {
-      "name": "@renovatebot/osv-offline-updater",
+      "name": "@mintmaker/osv-offline-updater",
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "20.1.1",
-        "@renovatebot/osv-offline-db": "0.0.0-semantic-release",
+        "@mintmaker/osv-offline-db": "0.0.0-semantic-release",
         "@seald-io/nedb": "4.0.4",
         "adm-zip": "0.5.16",
         "fs-extra": "11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@renovatebot/osv-offline-monorepo",
+  "name": "@mintmaker/osv-offline-monorepo",
   "private": true,
   "workspaces": [
     "./packages/*"
@@ -7,7 +7,7 @@
   "version": "0.0.0-semantic-release",
   "repository": {
     "type": "git",
-    "url": "https://github.com/renovatebot/osv-offline.git"
+    "url": "https://github.com/redhat-exd-rebuilds/osv-offline.git"
   },
   "scripts": {
     "build": "tsc --build",

--- a/packages/osv-offline-db/README.md
+++ b/packages/osv-offline-db/README.md
@@ -1,7 +1,7 @@
 # osv-offline-db
 
-[![Package version](https://img.shields.io/npm/v/@renovatebot/osv-offline-db?style=for-the-badge)](https://www.npmjs.com/package/@renovatebot/osv-offline-db)
-[![Build status](https://img.shields.io/github/actions/workflow/status/renovatebot/osv-offline/build.yml?branch=main&style=for-the-badge)](https://github.com/renovatebot/osv-offline/actions/workflows/build.yml)
+[![Package version](https://img.shields.io/npm/v/@mintmaker/osv-offline-db?style=for-the-badge)](https://www.npmjs.com/package/@mintmaker/osv-offline-db)
+[![Build status](https://img.shields.io/github/actions/workflow/status/mintmaker/osv-offline/build.yml?branch=main&style=for-the-badge)](https://github.com/mintmaker/osv-offline/actions/workflows/build.yml)
 [![MIT license](https://img.shields.io/badge/license-MIT-blue?style=for-the-badge)](./LICENSE)
 
 ## License

--- a/packages/osv-offline-db/package.json
+++ b/packages/osv-offline-db/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@renovatebot/osv-offline-db",
+  "name": "@mintmaker/osv-offline-db",
   "version": "0.0.0-semantic-release",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/renovatebot/osv-offline.git"
+    "url": "https://github.com/redhat-exd-rebuilds/osv-offline.git"
   },
   "dependencies": {
     "@seald-io/nedb": "^4.0.4"

--- a/packages/osv-offline-db/src/lib/db.int.spec.ts
+++ b/packages/osv-offline-db/src/lib/db.int.spec.ts
@@ -46,11 +46,53 @@ describe('lib/db', () => {
     _id: 'OBOFX1JDZQVO4hVE',
   };
 
+  const containerVuln: Vulnerability & { _id: string } = {
+    _id: "abcdef",
+    schema_version: "1.2.3",
+    id: "GHSA-22cc-w7xm-rfhx",
+    modified: "2024-06-21T19:36:07.296811Z",
+    published: "2024-06-20T19:53:30Z",
+    aliases: ["CVE-2019-7617", "PYSEC-2019-178"],
+    related: [
+      "CGA-2ph7-wp75-g3rf",
+      "CGA-326j-45xp-qqrg",
+      "CGA-3727-xg6m-m6g6"
+    ],
+    summary: "redis-py Race Condition vulnerability",
+    details:
+      "redis-py before 4.5.3, as used in ChatGPT and other products, leaves a connection open after canceling",
+    severity: [
+      {
+        type: "CVSS_V3",
+        score: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+      }
+    ],
+    affected: [
+      {
+        package: {
+          ecosystem: "Docker",
+          name: "quay.io/prometheus/node-exporter",
+          purl: "pkg:oci/assisted-installer-agent-rhel8@sha256:ca8d86079cd97908146284f1da90964c78cae7b9e45b7f44fb4c3c5e44c0cfb2?arch=arm64&repository_url=registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8&tag=v2.4.4-8"
+        }
+      },
+      {
+        package: {
+          ecosystem: "Docker",
+          name: "quay.io/prometheus/nodaae-exporter",
+          purl: "pkg:oci/assisted-installer-agent-rhel8@sha256:ca8d86079cd97908146284f1da90964c78cae7b9e45b7f44fb4c3c5e44c0cfb2?arch=arm64&repository_url=registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel8&tag=v2.4.4-8"
+        }
+      }
+    ]
+  }
+
   beforeAll(async () => {
     await fs.ensureDir(OsvOfflineDb.rootDirectory);
 
     const dbFile = path.join(OsvOfflineDb.rootDirectory, 'npm.nedb');
     await fs.writeFile(dbFile, JSON.stringify(sampleVuln), 'utf8');
+
+    const containerDbFile = path.join(OsvOfflineDb.rootDirectory, 'docker.nedb');
+    await fs.writeFile(containerDbFile, JSON.stringify(containerVuln), 'utf8');
 
     osvOfflineDb = await OsvOfflineDb.create();
   });
@@ -72,6 +114,19 @@ describe('lib/db', () => {
         'npm',
         'this-package-doesnt-exist'
       );
+
+      expect(result).toBeEmptyArray();
+    });
+  });
+
+  describe('query_containers', () => {
+    it('works', async () => {
+      const result = await osvOfflineDb.query_containers('quay.io/prometheus/node-exporter');
+      expect(result).toStrictEqual([containerVuln]);
+    });
+
+    it('returns empty array for invalid package', async () => {
+      const result = await osvOfflineDb.query_containers('this-package-doesnt-exist');
 
       expect(result).toBeEmptyArray();
     });

--- a/packages/osv-offline-db/src/lib/db.ts
+++ b/packages/osv-offline-db/src/lib/db.ts
@@ -48,4 +48,13 @@ export class OsvOfflineDb {
       },
     });
   }
+
+  async query_containers(
+    repository: string
+  ): Promise<Osv.Vulnerability[]> {
+    return await this.db["Docker" as Ecosystem].findAsync({
+      'affected.package.name': repository,
+      'affected.package.ecosystem': 'Docker'
+    });
+  }
 }

--- a/packages/osv-offline-db/src/lib/ecosystem.ts
+++ b/packages/osv-offline-db/src/lib/ecosystem.ts
@@ -11,5 +11,6 @@ export const ecosystems = [
   'Pub',
   'PyPI',
   'RubyGems',
+  'Docker',
 ] as const;
 export type Ecosystem = typeof ecosystems[number];

--- a/packages/osv-offline-db/src/lib/purl-helper.ts
+++ b/packages/osv-offline-db/src/lib/purl-helper.ts
@@ -13,6 +13,7 @@ const PURL_ECOSYSTEMS: Record<Ecosystem, string> = {
   PyPI: 'pypi',
   Pub: 'pub',
   RubyGems: 'gem',
+  Docker: 'docker',
 } as const;
 
 function urlEncode(packageName: string): string {

--- a/packages/osv-offline-updater/package.json
+++ b/packages/osv-offline-updater/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@renovatebot/osv-offline-updater",
+  "name": "@mintmaker/osv-offline-updater",
   "version": "0.0.0-semantic-release",
   "main": "src/index.ts",
   "license": "MIT",
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/renovatebot/osv-offline.git"
+    "url": "https://github.com/redhat-exd-rebuilds/osv-offline.git"
   },
   "scripts": {
     "start": "ts-node ./src/index.ts"
   },
   "dependencies": {
-    "@renovatebot/osv-offline-db": "0.0.0-semantic-release",
+    "@mintmaker/osv-offline-db": "0.0.0-semantic-release",
     "@octokit/rest": "20.1.1",
     "@seald-io/nedb": "4.0.4",
     "adm-zip": "0.5.16",

--- a/packages/osv-offline-updater/src/client/osv.ts
+++ b/packages/osv-offline-updater/src/client/osv.ts
@@ -2,7 +2,7 @@ import { format } from 'util';
 
 import AdmZip from 'adm-zip';
 import got from 'got';
-import type { Ecosystem, Osv } from '@renovatebot/osv-offline-db';
+import type { Ecosystem, Osv } from '@mintmaker/osv-offline-db';
 
 export class OsvDownloader {
   private static readonly downloadUrlFormat =

--- a/packages/osv-offline-updater/src/index.ts
+++ b/packages/osv-offline-updater/src/index.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import { Osv, OsvOfflineDb, ecosystems } from '@renovatebot/osv-offline-db';
+import { Osv, OsvOfflineDb, ecosystems } from '@mintmaker/osv-offline-db';
 import { GitHub } from './client/github';
 import signale from 'signale';
 import Datastore from '@seald-io/nedb';

--- a/packages/osv-offline/README.md
+++ b/packages/osv-offline/README.md
@@ -1,7 +1,7 @@
 # osv-offline
 
-[![Package version](https://img.shields.io/npm/v/@renovatebot/osv-offline?style=for-the-badge)](https://www.npmjs.com/package/@renovatebot/osv-offline)
-[![Build status](https://img.shields.io/github/actions/workflow/status/renovatebot/osv-offline/build.yml?branch=main&style=for-the-badge)](https://github.com/renovatebot/osv-offline/actions/workflows/build.yml)
+[![Package version](https://img.shields.io/npm/v/@mintmaker/osv-offline?style=for-the-badge)](https://www.npmjs.com/package/@mintmaker/osv-offline)
+[![Build status](https://img.shields.io/github/actions/workflow/status/mintmaker/osv-offline/build.yml?branch=main&style=for-the-badge)](https://github.com/mintmaker/osv-offline/actions/workflows/build.yml)
 [![MIT license](https://img.shields.io/badge/license-MIT-blue?style=for-the-badge)](./LICENSE)
 
 ## License

--- a/packages/osv-offline/package.json
+++ b/packages/osv-offline/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@renovatebot/osv-offline",
+  "name": "@mintmaker/osv-offline",
   "version": "0.0.0-semantic-release",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,10 +9,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/renovatebot/osv-offline.git"
+    "url": "https://github.com/redhat-exd-rebuilds/osv-offline.git"
   },
   "dependencies": {
-    "@renovatebot/osv-offline-db": "0.0.0-semantic-release",
+    "@mintmaker/osv-offline-db": "0.0.0-semantic-release",
     "@octokit/rest": "^20.1.1",
     "adm-zip": "~0.5.16",
     "fs-extra": "^11.2.0",

--- a/packages/osv-offline/src/index.ts
+++ b/packages/osv-offline/src/index.ts
@@ -1,2 +1,2 @@
-export { Osv, Ecosystem } from '@renovatebot/osv-offline-db';
+export { Osv, Ecosystem } from '@mintmaker/osv-offline-db';
 export { OsvOffline } from './lib/osv-offline';

--- a/packages/osv-offline/src/lib/download.int.spec.ts
+++ b/packages/osv-offline/src/lib/download.int.spec.ts
@@ -1,4 +1,4 @@
-import { OsvOfflineDb } from '@renovatebot/osv-offline-db';
+import { OsvOfflineDb } from '@mintmaker/osv-offline-db';
 import fs from 'fs-extra';
 import path from 'path';
 import { tryDownloadDb } from './download';

--- a/packages/osv-offline/src/lib/download.ts
+++ b/packages/osv-offline/src/lib/download.ts
@@ -4,7 +4,7 @@ import { Octokit } from '@octokit/rest';
 import got from 'got';
 import { Stream } from 'stream';
 import { promisify } from 'util';
-import { OsvOfflineDb } from '@renovatebot/osv-offline-db';
+import { OsvOfflineDb } from '@mintmaker/osv-offline-db';
 import path from 'path';
 import { DateTime } from 'luxon';
 import AdmZip from 'adm-zip';

--- a/packages/osv-offline/src/lib/osv-offline.int.spec.ts
+++ b/packages/osv-offline/src/lib/osv-offline.int.spec.ts
@@ -1,4 +1,4 @@
-import { OsvOfflineDb } from '@renovatebot/osv-offline-db';
+import { OsvOfflineDb } from '@mintmaker/osv-offline-db';
 import fs from 'fs-extra';
 import { OsvOffline } from './osv-offline';
 
@@ -17,17 +17,19 @@ describe('lib/osv-offline', () => {
   });
 
   describe('getVulnerabilities', () => {
-    it('works', async () => {
-      const result = await osvOffline.getVulnerabilities('npm', 'lodash');
-
-      expect(result).not.toBeEmptyArray();
-    });
-
     it('returns empty array for invalid package', async () => {
       const result = await osvOffline.getVulnerabilities(
         'npm',
         'this-package-doesnt-exist'
       );
+
+      expect(result).toBeEmptyArray();
+    });
+  });
+
+  describe('getContainerVulnerabilities', () => {
+    it('returns empty array for invalid package', async () => {
+      const result = await osvOffline.getContainerVulnerabilities("quay.io/some/repo");
 
       expect(result).toBeEmptyArray();
     });

--- a/packages/osv-offline/src/lib/osv-offline.ts
+++ b/packages/osv-offline/src/lib/osv-offline.ts
@@ -1,4 +1,4 @@
-import { Ecosystem, Osv, OsvOfflineDb } from '@renovatebot/osv-offline-db';
+import { Ecosystem, Osv, OsvOfflineDb } from '@mintmaker/osv-offline-db';
 import { tryDownloadDb } from './download';
 
 export class OsvOffline {
@@ -39,5 +39,16 @@ export class OsvOffline {
     packageName: string
   ): Promise<Osv.Vulnerability[]> {
     return this.osvOfflineDb.query(ecosystem, packageName);
+  }
+
+  /**
+   * Query the local database for any container vulnerabilities
+   * @param repository The repository name (in the format of <registry>/<org>/<repo>)
+   * @returns An array of {@link Osv.Vulnerability} or an empty array if none are found
+   */
+   async getContainerVulnerabilities(
+    repository: string
+  ): Promise<Osv.Vulnerability[]> {
+    return this.osvOfflineDb.query_containers(repository);
   }
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -4,7 +4,7 @@
     // ts-jest doesn't understand project references, so tell it how to find our packages
     // (see https://github.com/kulshekhar/ts-jest/issues/1648)
     "paths": {
-      "@renovatebot/*": ["./packages/*"]
+      "@mintmaker/*": ["./packages/*"]
     }
   }
 }


### PR DESCRIPTION
A new org "mintmaker" has been created in npm and our downstream fork of osv-offline will start to be released as @mintmaker/osv-offline.

Add support for container vulnerabilities, osv-offline is not able to consume docker.nedb file and filter vulnerabilities based on a matching affected repo.